### PR TITLE
Include wiki link in edit message

### DIFF
--- a/main.js
+++ b/main.js
@@ -615,7 +615,7 @@ rmCloser.notifyEvaluate = function(e) {
 				text += "\n\n== Requested move at [[" + pageAndSection + "]] ==\n[[File:Information.svg|30px|left]] There is a requested move discussion at [[" + pageAndSection + "]] that may be of interest to members of this WikiProject. ~~~~";
 
 				talkpage.setPageText(text);
-				talkpage.setEditSummary('Notifying of requested move' + rmCloser.advert);
+				talkpage.setEditSummary('Notifying of requested move [["' + pageAndSection + '"]]' + rmCloser.advert);
 				talkpage.save(Morebits.status.actionCompleted('Notified.'));
 				notified = true;
 			} else{


### PR DESCRIPTION
```javascript
// pageAndSection => example
talkpage.setEditSummary('Notifying of requested move [[' + pageAndSection + ']]' + rmCloser.advert);
// Notifying of requested move [[example]] using rmCloser
```

Could also do 

```javascript
talkpage.setEditSummary('Notifying of [[' + pageAndSection + '\|requested move]]' + rmCloser.advert);
```