### PR TITLE
main.js: Don't crash when WikiProject banner has children without titles

### DIFF
--- a/main.js
+++ b/main.js
@@ -754,10 +754,12 @@ rmCloser.notify = function rmCloserNotify(e) {
 				subprojectList = subprojectList.children;
 				for (var j=0; j<subprojectList.length; j++) {
 					var wikiProjectName = subprojectList[j].title;
-					var wikiProjectTalk = mw.Title.newFromText(subprojectList[j].title).getTalkPage().toText();
-					if (!wikiProjectNames.includes(wikiProjectName)) {
-						wikiProjectNames.push(wikiProjectName);
-						wikiProjects.push(wikiProjectTalk);
+					if (mw.Title.newFromText(wikiProjectName)) {
+						var wikiProjectTalk = mw.Title.newFromText(wikiProjectName).getTalkPage().toText();
+						if (!wikiProjectNames.includes(wikiProjectName)) {
+							wikiProjectNames.push(wikiProjectName);
+							wikiProjects.push(wikiProjectTalk);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes crashes when notifying WikiProjects in cases like the Articles for creation Wikiproject banner, which has a checkmark to indicate when the draft was reviewed that isn't a link to a subproject.